### PR TITLE
dashboard improvements

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -26,11 +26,35 @@ class HomeController extends Controller
     {
         $tasks = [];
         $bids = [];
+        $selectedBids = [];
         if (Auth::check()) {
             $id = Auth::id();
             $tasks = $this->tasksRepo->belongsTo($id);
-            $bids = $this->bidsRepo->belongsTo($id);
+            $bids = $this->bidsRepo->getOpenedBids($id);
+            $selectedBids = $this->bidsRepo->getSelectedBids($id);
+
+            // formatting times
+            foreach($tasks as $task){
+                $strToTime = strToTime($task->start_date);
+                $task->start_date = date('Y-m-d H:i', $strToTime);
+                $strToTime = strToTime($task->end_date);
+                $task->end_date = date('Y-m-d H:i', $strToTime);
+            }
+
+            foreach($bids as $bid){
+                $strToTime = strToTime($bid->start_date);
+                $bid->start_date = date('Y-m-d H:i', $strToTime);
+                $strToTime = strToTime($bid->end_date);
+                $bid->end_date = date('Y-m-d H:i', $strToTime);
+            }
+
+            foreach($selectedBids as $selectedBid){
+                $strToTime = strToTime($selectedBid->start_date);
+                $selectedBid->start_date = date('Y-m-d H:i', $strToTime);
+                $strToTime = strToTime($selectedBid->end_date);
+                $selectedBid->end_date = date('Y-m-d H:i', $strToTime);
+            }
         }
-        return view('home', compact('tasks', 'bids'));
+        return view('home', compact('tasks', 'bids', 'selectedBids'));
     }
 }

--- a/app/Repositories/Bids.php
+++ b/app/Repositories/Bids.php
@@ -27,4 +27,18 @@ class Bids
             AND b.task_id = t.id AND t.owner = u.id', [$id]);
         return $bids;
     }
+
+    public function getOpenedBids($id)
+    {
+        $bids = DB::select('SELECT * FROM Bids b, Tasks t, Users u WHERE user_id=?
+            AND b.task_id = t.id AND t.owner = u.id AND t.status=0', [$id]);
+        return $bids;
+    }
+
+    public function getSelectedBids($id)
+    {
+        $bids = DB::select('SELECT * FROM Bids b, Tasks t, Users u WHERE user_id=?
+            AND b.task_id = t.id AND t.owner = u.id AND b.selected=true', [$id]);
+        return $bids;
+    }
 }

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -30,15 +30,37 @@
                         <tr>
                             <th>Title</th>
                             <th>Category</th>
+                            <th>Start</th>
+                            <th>End</th>
                             <th>Status</th>
-                            <th>End Date</th>
+                            <th><!-- edit button placeholder--></th>
                         </tr>
                         @foreach ($tasks as $task)
                         <tr onclick="window.document.location='tasks/{{$task->id}}';">
                             <td>{{$task->title}}</td>
                             <td>{{$task->category}}</td>
-                            <td>{{$task->status}}</td>
+                            <td>{{$task->start_date}}</td>
                             <td>{{$task->end_date}}</td>
+                            <td>
+                                @php
+                                    switch($task->status) {
+                                        case 0:
+                                            print("opened");
+                                            break;
+                                        case 1:
+                                            print("closed");
+                                            break;
+                                        case 2:
+                                            print("completed");
+                                            break;
+                                        default:
+                                            break;
+                                    }
+                                @endphp
+                            </td>
+                            <td>
+                                <a href="tasks/{{$task->id}}/edit" class="btn btn-primary">Edit</a>
+                            </td>
                         </tr>
                         @endforeach
                     </table>
@@ -52,39 +74,76 @@
                 </div>
             </div>
 
-            <!-- YOUR BIDS PANEL -->
+            <!-- YOUR PENDING BIDS PANEL -->
             <div class="col-md-8 col-md-offset-2">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h3 class="panel-title">
-                            Your Bids
+                            Your Pending Bids
                             <a href="tasks" style="color:#3097D1; float:right">View Tasks</a>
                         </h3>
                     </div>
                     @if (sizeOf($bids)>0)
-                    <table class="table">
+                    <table class="table table-hover">
                         <tr>
-                            <th>Task ID</th>
                             <th>Title</th>
                             <th>Owner</th>
                             <th>Price</th>
-                            <th>Selected</th>
+                            <th>Start</th>
+                            <th>End</th>
                         </tr>
                         @foreach ($bids as $bid)
-                        <tr>
-                            <td>{{$bid->task_id}}</td>
+                        <tr onclick="window.document.location='tasks/{{$bid->task_id}}';">
                             <td>{{$bid->title}}</td>
                             <td>{{$bid->first_name}} {{$bid->last_name}}</td>
                             <td>{{$bid->price}}</td>
-                            <td>{{$bid->selected}}</td>
+                            <td>{{$bid->start_date}}</td>
+                            <td>{{$bid->end_date}}</td>
                         </tr>
                         @endforeach
                     </table>
                     @else
                     <div class="panel-body">
-                        You currently have no bids. Click
+                        You currently have no pending bids. Click
                         <a href="tasks">here</a>
-                        to view other people's tasks.
+                        to find tasks to complete.
+                    </div>
+                    @endif
+                </div>
+            </div>
+
+            <!-- YOUR ASSIGNED TASKS PANEL -->
+            <div class="col-md-8 col-md-offset-2">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3 class="panel-title">
+                            Your Assigned Tasks
+                        </h3>
+                    </div>
+                    @if (sizeOf($selectedBids)>0)
+                    <table class="table table-hover">
+                        <tr>
+                            <th>Title</th>
+                            <th>Owner</th>
+                            <th>Price</th>
+                            <th>Start</th>
+                            <th>End</th>
+                        </tr>
+                        @foreach ($selectedBids as $selectedBid)
+                        <tr onclick="window.document.location='tasks/{{$selectedBid->task_id}}';">
+                            <td>{{$selectedBid->title}}</td>
+                            <td>{{$selectedBid->first_name}} {{$selectedBid->last_name}}</td>
+                            <td>{{$selectedBid->price}}</td>
+                            <td>{{$selectedBid->start_date}}</td>
+                            <td>{{$selectedBid->end_date}}</td>
+                        </tr>
+                        @endforeach
+                    </table>
+                    @else
+                    <div class="panel-body">
+                        You currently have no assigned tasks. Click
+                        <a href="tasks">here</a>
+                        to find tasks to complete.
                     </div>
                     @endif
                 </div>


### PR DESCRIPTION
https://github.com/ProjectTwentyFive/task-sourcing/issues/13
- link bid to individual task page #41
- View assigned tasks
- show status of my tasks instead of the id (0, 1, 2)
- change your bids to pending bids (only show opened bids)
- remove selected column for your pending bids and show end date instead
- button that links to editing task